### PR TITLE
Nested pages

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,6 +7,8 @@ Simply copy the `Fetch` folder into `site/addons/`. That's it!
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `deep` | Boolean | `true` | Fetch nested data recursively, works for arrays as well as related content. |
+| `nested` | Boolean | `false` | Add child pages to the page instead of the root of the response. |
+| `depth` | Integer | `0` | Depth of nested page to fetch. Only works `nested`. `0` means unlimited. |
 | `filter` | String | `null` | Filter `published` and `unpublished` data. |
 | `taxonomy` | String | `null` | Filter data by a single or multiple taxonomies. |
 | `locale` | String | `null` | Fetch data for a specific locale. |
@@ -26,6 +28,7 @@ The settings page is accessed via `CP > Configure > Addons > Fetch`.
 | Name | Type | Description |
 |------|------|-------------|
 | **Deep** | Boolean | Site default to 'go deep' when fetching data. |
+| **Nested** | Boolean | Site default to 'nested' parameter when fetching data. |
 | **Enable API Key** | Boolean | Whether to use the API Key for authentication. |
 | **API Key** | String | Generate an API Key. Only used when `Enable API Key` is set to `true`. |
 | **IP Whitelist** | Array | List of whitelisted IP addresses. Leave blank to allow any. |
@@ -56,6 +59,7 @@ This behavior can be disabled via Fetch's settings (CP > Configure > Addons > Fe
 | Name | Example |
 |------|---------|
 | `deep` | URL: `http://domain.com/!/Fetch/collection/blog?deep=true` <br> Tag: `{{ fetch:blog deep="true" }}` |
+| `nested` | URL: `http://domain.com/!/Fetch/collection/blog?nested=true` <br> Tag: `{{ fetch:blog nested="true" }}` |
 | `filter` | URL: `http://domain.com/!/Fetch/collection/blog?filter=published` <br> Tag: `{{ fetch:blog filter="published" }}` |
 | `taxonomy` | URL: `http://domain.com/!/Fetch/collection/blog?taxonomy=tags/news` <br> Tag: `{{ fetch:blog taxonomy="tags/news" }}` |
 | `locale` | URL: `http://domain.com/!/Fetch/collection/blog?locale=nl` <br> Tag: `{{ fetch:blog locale="nl" }}` |
@@ -141,6 +145,11 @@ Fetch multiple pages
 var pages = '/, /about, /contact-us';
 
 axios.get('/!/Fetch/pages/?pages='+encodeURIComponent(pages)).then(...);
+```
+
+Fetch pages nested
+```javascript
+axios.get('/!/Fetch/pages/?nested=true&depth=5').then(...);
 ```
 
 **Tag**

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -8,7 +8,7 @@ Simply copy the `Fetch` folder into `site/addons/`. That's it!
 |------|------|---------|-------------|
 | `deep` | Boolean | `true` | Fetch nested data recursively, works for arrays as well as related content. |
 | `nested` | Boolean | `false` | Add child pages to the page instead of the root of the response. |
-| `depth` | Integer | `0` | Depth of nested page to fetch. Only works `nested`. `0` means unlimited. |
+| `depth` | Integer | `null` | Depth of nested page to fetch. Only works `nested`. `null` means unlimited. |
 | `filter` | String | `null` | Filter `published` and `unpublished` data. |
 | `taxonomy` | String | `null` | Filter data by a single or multiple taxonomies. |
 | `locale` | String | `null` | Fetch data for a specific locale. |

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -232,7 +232,7 @@ class Fetch
                     function (\Statamic\Data\Pages\Page $page) {
                         return $this->addChildPagesToPage($page);
                     }
-                )->all();
+                );
             }
         }
 

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -48,7 +48,7 @@ class Fetch
         $this->auth = (new FetchAuth)->isAuth();
         $this->deep = $this->checkDeep($params);
         $this->nested = bool(request('nested', $params->get('nested', $this->getConfigBool('nested'))));
-        $this->depth = (int) (request('depth') ?: $params->get('depth', 0));
+        $this->depth = request('depth', $params->get('depth', null));
         $this->debug = bool(request('debug', $params->get('debug')));
         $this->locale = request('locale') ?: $params->get('locale') ?: default_locale();
 

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -4,7 +4,6 @@ namespace Statamic\Addons\Fetch;
 
 use Carbon\Carbon;
 use Statamic\API\Str;
-use Statamic\API\URL;
 use Statamic\API\Page;
 use Statamic\API\Asset;
 use Statamic\API\Entry;
@@ -401,7 +400,7 @@ class Fetch
         $item = collect($item)->map(function ($value, $key) {
             if (is_array($value)) {
                 return collect($value)->map(function ($value) {
-                   return $this->goDeep($value);
+                    return $this->goDeep($value);
                 });
             }
 

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -221,7 +221,7 @@ class Fetch
             }
         }
 
-        if ($this->deep) {
+        if ($this->deep && ! $this->nested) {
             $this->processData();
         }
 

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -47,7 +47,7 @@ class Fetch
 
         $this->auth = (new FetchAuth)->isAuth();
         $this->deep = $this->checkDeep($params);
-        $this->nested = $this->checkNested($params);
+        $this->nested = bool(request('nested', $params->get('nested', $this->getConfigBool('nested'))));
         $this->depth = (int) (request('depth') ?: $params->get('depth', 0));
         $this->debug = bool(request('debug', $params->get('debug')));
         $this->locale = request('locale') ?: $params->get('locale') ?: default_locale();
@@ -486,16 +486,6 @@ class Fetch
         $param = request('deep', $params->get('deep'));
 
         return is_null($param) ? $this->getConfigBool('deep') : bool($param);
-    }
-
-    private function checkNested($params)
-    {
-        $param = request('nested', $params->get('nested'));
-        if ($param !== null) {
-            return bool($param);
-        }
-
-        return $this->getConfigBool('nested');
     }
 
     private function addChildPagesToPage(\Statamic\Data\Pages\Page $page): array

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -42,7 +42,7 @@ class Fetch
 
         $this->auth = (new FetchAuth)->isAuth();
         $this->deep = $this->checkDeep($params);
-        $this->debug = bool(request('debug'), $params->get('debug'));
+        $this->debug = bool(request('debug', $params->get('debug')));
         $this->locale = request('locale') ?: $params->get('locale') ?: default_locale();
 
         $this->page = (int) (request('page') ?: $params->get('page', 1));

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -20,6 +20,8 @@ class Fetch
 
     public $auth;
     public $deep;
+    public $nested;
+    public $depth;
     public $debug;
     public $locale;
 
@@ -44,6 +46,8 @@ class Fetch
 
         $this->auth = (new FetchAuth)->isAuth();
         $this->deep = $this->checkDeep($params);
+        $this->nested = $this->checkNested($params);
+        $this->depth = (int) (request('depth') ?: $params->get('depth', 0));
         $this->debug = bool(request('debug', $params->get('debug')));
         $this->locale = request('locale') ?: $params->get('locale') ?: default_locale();
 
@@ -461,5 +465,15 @@ class Fetch
         $param = request('deep', $params->get('deep'));
 
         return is_null($param) ? $this->getConfigBool('deep') : bool($param);
+    }
+
+    private function checkNested($params)
+    {
+        $param = request('nested', $params->get('nested'));
+        if ($param !== null) {
+            return bool($param);
+        }
+
+        return $this->getConfigBool('nested');
     }
 }

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -33,6 +33,8 @@ class Fetch
     private $query;
     private $isSearch;
 
+    /** @var \Illuminate\Support\Collection */
+    private $data;
     private $hasNextPage;
     private $totalResults;
 

--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -490,7 +490,7 @@ class Fetch
 
     private function addChildPagesToPage(\Statamic\Data\Pages\Page $page): array
     {
-        $data = $page->toArray();
+        $data = $this->getPageData($page);
 
         $depth = $this->depth > 0 ? $this->depth : null;
         $children = collect(Content::tree($data['uri'], $depth, false, false, null, $this->locale));
@@ -505,7 +505,7 @@ class Fetch
 
     private function processNestedPage(array $item): array
     {
-        $page = $item['page']->toArray();
+        $page = $this->getPageData($item['page']);
 
         if ($item['children']) {
             $page['children'] = collect($item['children'])->map(function ($item) {
@@ -514,5 +514,14 @@ class Fetch
         }
 
         return $page;
+    }
+
+    private function getPageData(\Statamic\Data\Pages\Page $page): array
+    {
+        if ($this->deep) {
+            $page->supplementTaxonomies();
+        }
+
+        return $page->toArray();
     }
 }

--- a/Fetch/FetchAuth.php
+++ b/Fetch/FetchAuth.php
@@ -50,7 +50,7 @@ class FetchAuth
         if (! getenv('HTTP_ORIGIN')) {
             return true;
         }
-        
+
         if (in_array(getenv('HTTP_ORIGIN'), $this->getConfig('domain_whitelist', []))) {
             return true;
         }

--- a/Fetch/FetchTags.php
+++ b/Fetch/FetchTags.php
@@ -3,7 +3,6 @@
 namespace Statamic\Addons\Fetch;
 
 use Statamic\Extend\Tags;
-use Statamic\API\Collection;
 
 class FetchTags extends Tags
 {

--- a/Fetch/default.yaml
+++ b/Fetch/default.yaml
@@ -1,4 +1,5 @@
 deep: true
+nested: false
 enable_api_key: false
 api_key: ''
 ip_whitelist: []

--- a/Fetch/settings.yaml
+++ b/Fetch/settings.yaml
@@ -4,6 +4,11 @@ fields:
   deep:
     type: toggle
     instructions: If set to false, you can manually add it to a request using <code>?deep=true</code>
+    width: 50
+  nested:
+    type: toggle
+    instructions: If set to false, you can manually add it to a request using <code>?nested=true</code>
+    width: 50
   index_collections:
     type: collections
     display: Auto-Index Collections


### PR DESCRIPTION
Implement #25 

Enabling `nested` will nest the pages like following
``` js
data: {
  // ... pageData
  children:  [
    { /* subpage */ },
    { /* subpage */ },
  ]
}
```

I think `deep` will not work correctly with `nested`, _see comments_

## TODO
- [ ] version bump