### PR TITLE
Make Fetch and FetchAuth available as services

### DIFF
--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -41,11 +41,15 @@ class Fetch
     private $hasNextPage;
     private $totalResults;
 
-    public function __construct($params = null)
+    public function __construct(FetchAuth $fetchAuth)
+    {
+        $this->auth = $fetchAuth->isAuth();
+    }
+
+    public function setParameters(array $params)
     {
         $params = collect($params);
 
-        $this->auth = (new FetchAuth)->isAuth();
         $this->deep = $this->checkDeep($params);
         $this->debug = bool(request('debug', $params->get('debug')));
         $this->depth = (int) (request('depth', $params->get('depth', null)));

--- a/Fetch/FetchController.php
+++ b/Fetch/FetchController.php
@@ -2,15 +2,19 @@
 
 namespace Statamic\Addons\Fetch;
 
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
 use Statamic\Extend\Controller;
 
 class FetchController extends Controller
 {
     private $fetch;
 
-    public function __construct()
+    public function __construct(Fetch $fetch)
     {
-        $this->fetch = new Fetch;
+        parent::__construct();
+
+        $this->fetch = $fetch;
 
         if (! $this->fetch->auth) {
             header("HTTP/1.1 401 Unauthorized");
@@ -20,71 +24,84 @@ class FetchController extends Controller
 
     public function getCollection()
     {
-        return $this->fetch->collection();
+        return $this->response($this->fetch->collection());
     }
 
     public function postCollection()
     {
-        return $this->fetch->collection();
+        return $this->response($this->fetch->collection());
     }
 
     public function getEntry()
     {
-        return $this->fetch->entry();
+        return $this->response($this->fetch->entry());
     }
 
     public function postEntry()
     {
-        return $this->fetch->entry();
+        return $this->response($this->fetch->entry());
     }
 
     public function getPage()
     {
-        return $this->fetch->page();
+        return $this->response($this->fetch->page());
     }
 
     public function postPage()
     {
-        return $this->fetch->page();
+        return $this->response($this->fetch->page());
     }
 
     public function getPages()
     {
-        return $this->fetch->pages();
+        return $this->response($this->fetch->pages());
     }
 
     public function postPages()
     {
-        return $this->fetch->pages();
+        return $this->response($this->fetch->pages());
     }
 
     public function getGlobal()
     {
-        return $this->fetch->global();
+        return $this->response($this->fetch->global());
     }
 
     public function postGlobal()
     {
-        return $this->fetch->global();
+        return $this->response($this->fetch->global());
     }
 
     public function getGlobals()
     {
-        return $this->fetch->globals();
+        return $this->response($this->fetch->globals());
     }
 
     public function postGlobals()
     {
-        return $this->fetch->globals();
+        return $this->response($this->fetch->globals());
     }
 
     public function getSearch()
     {
-        return $this->fetch->search();
+        return $this->response($this->fetch->search());
     }
 
     public function postSearch()
     {
-        return $this->fetch->search();
+        return $this->response($this->fetch->search());
+    }
+
+    private function response($data) {
+        if ($data instanceof Response) {
+            $response = $data;
+        } else {
+            $fetchData = $data instanceof Collection ? $data->toArray() : [];
+            $response = response()->json($fetchData);
+        }
+
+        $this->emitEvent('response.created', $response);
+
+        return $response;
     }
 }

--- a/Fetch/FetchServiceProvider.php
+++ b/Fetch/FetchServiceProvider.php
@@ -9,6 +9,17 @@ class FetchServiceProvider extends ServiceProvider
 {
     public $defer = true;
 
+    public function register()
+    {
+        $this->app->singleton(FetchAuth::class, function () {
+            return new FetchAuth();
+        });
+
+        $this->app->singleton(Fetch::class, function ($app) {
+            return new Fetch($app[FetchAuth::class]);
+        });
+    }
+
     public function boot()
     {
         $excludes = Config::get('system.csrf_exclude', []);
@@ -18,5 +29,13 @@ class FetchServiceProvider extends ServiceProvider
             $excludes[] = $actionUrl;
             Config::set('system.csrf_exclude', $excludes);
         }
+    }
+
+    public function provides()
+    {
+        return [
+            FetchAuth::class,
+            Fetch::class,
+        ];
     }
 }

--- a/Fetch/FetchTags.php
+++ b/Fetch/FetchTags.php
@@ -13,7 +13,8 @@ class FetchTags extends Tags
      */
     public function __call($method, $args)
     {
-        $this->fetch = new Fetch($this->parameters);
+        $this->fetch = app(Fetch::class);
+        $this->fetch->setParameters($this->parameters);
 
         if ($name = explode(':', $this->tag)[1]) {
             if ($name === 'pages') {
@@ -33,7 +34,8 @@ class FetchTags extends Tags
      */
     public function index()
     {
-        $this->fetch = new Fetch($this->parameters);
+        $this->fetch = app(Fetch::class);
+        $this->fetch->setParameters($this->parameters);
 
         $types = collect(['collection', 'entry', 'page', 'pages', 'global', 'globals']);
 


### PR DESCRIPTION
First of all, thank you for creating this Addon, it rocks! 👍 

We had the need to customize the authentication by only allowing registered users to consume the Fetch API.

* This pull request registers the `Fetch` and `FetchAuth` classes as singleton services in Laravel's service container, allowing them to be extended or decorated.
* Furthermore we needed to add some CORS headers to the response returned by Fetch. I tried to add them via custom HTTP middleware, but it seems that these are getting bypassed when the request is handled by an Addon controller in the frontend. The Addon now emits an event when the response is created, allowing event listeners to modify the response (similar to Statamic's `response.created`) event.

Note that the constructor of the `Fetch` class changed its signature, as we need a dependency injection for the `FetchAuth` class. Parameters are now injected via `Fetch::setParameters()`. I am not sure if you consider this a BC break. Other than that, the changes should be fully backwards compatible.

Here is an example for a custom decorated `FetchAuth` service:

```php
// The decorated service
class FetchAuthDecorator extends FetchAuth
{
    private $fetchAuth;

    public function __construct(FetchAuth $fetchAuth)
    {
        $this->fetchAuth = $fetchAuth;
    }

    public function isAuth()
    {
        if (!$this->fetchAuth->isAuth()) {
            return false;
        }

        return User::loggedIn();
    }
}

// The registration in the service provider
$this->app->extend(FetchAuth::class, function ($fetchAuth) {
    return new FetchAuthDecorator($fetchAuth);
});
```

Cheers