### PR TITLE
Add functionality for fetching Taxonomy by handle

### DIFF
--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -11,6 +11,7 @@ use Statamic\API\Search;
 use Statamic\API\Content;
 use Statamic\API\GlobalSet;
 use Statamic\API\Collection;
+use Statamic\API\Taxonomy;
 use Statamic\Extend\Extensible;
 use Statamic\Data\Pages\PageCollection;
 use Statamic\Data\Pages\Page as PageData;
@@ -217,6 +218,22 @@ class Fetch
         });
 
         return $this->handle($data);
+    }
+
+    /**
+     * Fetch taxonomy
+     */
+    public function taxonomy($name = null)
+    {
+        $name = $name ?: request()->segment(4);
+
+        if (! $taxonomy = Taxonomy::whereHandle($name)) {
+            $message =  "Taxonomy [$name] not found.";
+
+            return request()->isJson() ? response($message, 404) : $message;
+        }
+
+        return Taxonomy::whereHandle($name)->terms();
     }
 
     /**

--- a/Fetch/FetchController.php
+++ b/Fetch/FetchController.php
@@ -93,6 +93,16 @@ class FetchController extends Controller
         return $this->response($this->fetch->search());
     }
 
+    public function getTaxonomy()
+    {
+        return $this->response($this->fetch->taxonomy());
+    }
+
+    public function postTaxonomy()
+    {
+        return $this.response($this->fetch->taxonomy());
+    }
+
     private function response($data) {
         if ($data instanceof Response) {
             $response = $data;


### PR DESCRIPTION
I needed this functionality for my own project, so I figured I'd add a pull request in case you wanted to add it.

Taxonomy would be retrievable using this format: http://domain.com/!/Fetch/taxonomy/{handle}
