### PR TITLE
Fix Fetching of Localized Taxonomies

### DIFF
--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -232,7 +232,7 @@ class Fetch
         $this->deep = false;
 
         $taxonomies = Taxonomy::all()->map(function ($taxonomy) {
-            return $taxonomy->terms();
+            return $taxonomy->terms()->localize($this->locale);
         });
 
         return $this->handle($taxonomies);
@@ -256,7 +256,7 @@ class Fetch
             return request()->isJson() ? response($message, 404) : $message;
         }
 
-        return $this->handle($taxonomy->terms());
+        return $this->handle($taxonomy->terms()->localize($this->locale));
     }
 
     /**


### PR DESCRIPTION
Hi!
In my project the ?local=xx did not work on localized taxonomies.
Given the following taxonomy file `tags.yaml`:
```
title: English
fr:
  title: French
```

the request

`/!/Fetch/taxonomy/tags?locale=fr`

returns 
```
 "tags": [
    {
      "title": "English",
       ...
    }
```
Not sure if this is the cleanest / correct solution but does work for me as far as I can see.