### PR TITLE
feature: add support for logical and filtering by taxonomy

### DIFF
--- a/Fetch/Fetch.php
+++ b/Fetch/Fetch.php
@@ -451,18 +451,20 @@ class Fetch
     private function taxonomizeData()
     {
         if ($this->taxonomy) {
-            $this->data = $this->data->filter(function ($entry) {
-                $taxonomies = collect(explode('|', $this->taxonomy));
+            foreach((array)$this->taxonomy as $taxonomyFilter) {
+                $this->data = $this->data->filter(function ($entry) use ($taxonomyFilter) {
+                    $taxonomies = collect(explode('|', $taxonomyFilter));
 
-                return $taxonomies->first(function ($key, $value) use ($entry) {
-                    list($taxonomy, $term) = explode('/', $value);
+                    return $taxonomies->first(function ($key, $value) use ($entry) {
+                        list($taxonomy, $term) = explode('/', $value);
 
-                    return collect($entry->get($taxonomy))
-                        ->contains(function ($key, $value) use ($term) {
-                            return $term === slugify($value);
-                        });
+                        return collect($entry->get($taxonomy))
+                            ->contains(function ($key, $value) use ($term) {
+                                return $term === slugify($value);
+                            });
+                    });
                 });
-            });
+            }
         }
 
         return $this;


### PR DESCRIPTION
I had the task to implement a filter system accross multiple taxonomies. 
The current system only allowed for one _taxonomy_ parameter in the request, taxonomies were separated by '|' and handled as logical **or**. 
https://example.com/!/Fetch/collection/xxx?&taxonomy=category1/foo|category2/bar
This would return all collection with the logical condition:
`category1 == foo || category2 == bar`

With multiple _taxonomy_ parameters, only one was registered (the last one)
https://example.com/!/Fetch/collection/xxx?&taxonomy=category/foo&taxonomy=category/bar
This would return all collection with the logical condition:
`category2 == bar` (the first taxonomy parameter is ignored when multiple parameters have the same name)

What I did was add the possibility to combine multiple taxonomy parameters to an array in the request:
https://example.com/!/Fetch/collection/xxx?&taxonomy[]=category1/foo&taxonomy[]=category2/bar

Now the taxonomy parameter cought by the `setParameters()` function will contain an array and each taxonomy (or taxonomy group) in the array will be handled separatly.

so the above request would rerun all collections with the condition:
`category1 == foo && category2 == bar`

these methods can be combined, so:
https://example.com/!/Fetch/collection/xxx?&taxonomy[]=category1/foo|category3/fizz&taxonomy[]=category2/bar|category3/buzz
would return collections with:

`(category1 == foo || categroy3 == fizz) && (category2 == bar || categroy3 == buzz)`